### PR TITLE
Change getAll permission checking.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -206,24 +206,41 @@ api.inboxes.getAll = function(actor, query, fields, options, callback) {
 
   query = query || {};
   fields = fields || {};
+  // meta is required for permission check, if meta was not a specified field
+  // it will be removed later
+  // TODO: this same concept might be applied to making sure the `id` field
+  // is also present for the permission check
+  let stripMeta = false;
+  if(Object.keys(fields).length > 0 && !fields.meta) {
+    stripMeta = true;
+    fields.meta = true;
+  }
   options = options || {};
   async.auto({
-    // need inbox access capability for all resources to use this
-    checkPermission: callback => brPermission.checkPermission(
-      actor, PERMISSIONS.LDN_INBOX_ACCESS, callback),
-    find: ['checkPermission', (results, callback) => inboxCollection.find(
-      query, fields, options).toArray(callback)]
+    find: callback => inboxCollection.find(query, fields, options)
+      .toArray(callback),
+    // check to make sure the caller is allowed to access the inbox
+    // (Note: fields *must not* have excluded `inbox.id` in this
+    // case or else the look up for the permission check will fail)
+    getAuthorized: ['find', (results, callback) => async.filterSeries(
+      results.find, (record, callback) => brPermission.checkPermission(
+        actor, PERMISSIONS.LDN_INBOX_ACCESS, {
+          resource: [record.inbox.id, record.meta.owner]
+        }, err => callback(null, !err)), callback)]
   }, (err, results) => {
     if(err) {
       return callback(err);
     }
     // decode records
-    for(const record of results.find) {
+    for(const record of results.getAuthorized) {
+      if(stripMeta) {
+        delete record.meta;
+      }
       if('message' in record) {
         record.inbox = database.decode(record.inbox);
       }
     }
-    callback(null, results.find);
+    callback(null, results.getAuthorized);
   });
 };
 

--- a/test/Gruntfile.js
+++ b/test/Gruntfile.js
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+module.exports = function(grunt) {
+  grunt.initConfig({
+    shell: {
+      target: 'npm test'
+    },
+    watch: {
+      files: ['**/*', '!node_modules/**/*', '!bower_components/**/*'],
+      tasks: ['shell']
+    }
+  });
+  grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-shell');
+};

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -34,7 +34,7 @@ api.createMessage = function(mockData, options = {addId: true}) {
 api.createIdentity = function(options) {
   var userName = options.userName || uuid();
   var newIdentity = {
-    id: api.IDENTITY_BASE_PATH + '/' + userName,
+    id: api.IDENTITY_BASE_PATH + userName,
     type: 'Identity',
     sysSlug: userName,
     label: userName,

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -10,7 +10,6 @@ module.exports = mock;
 
 const identities = mock.identities = {};
 let userName;
-let keyId;
 
 userName = 'regularUser';
 identities[userName] = {};
@@ -27,6 +26,17 @@ identities[userName].identity.sysResourceRole.push({
   sysRole: 'bedrock-ldn-inbox.test'
 });
 
-mock.inbox = {};
+mock.inbox = {
+  type: 'Container',
+  '@context': [
+    'https://www.w3.org/ns/ldp',
+    {
+      owner: {
+        '@id': 'https://w3id.org/security#owner',
+        '@type': '@id'
+      }
+    }
+  ]
+};
 
 mock.message = {};

--- a/test/package.json
+++ b/test/package.json
@@ -6,7 +6,8 @@
   "main": "test",
   "scripts": {
     "test": "node --preserve-symlinks test.js test",
-    "ci-test": "node --preserve-symlinks test.js test --mocha-reporter=tap"
+    "ci-test": "node --preserve-symlinks test.js test --mocha-reporter=tap",
+    "watch": "grunt watch"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,10 @@
     "bedrock-mongodb": "^3.2.0",
     "bedrock-permission": "^2.4.0",
     "bedrock-test": "^1.0.0",
+    "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "grunt-shell": "^2.1.0",
     "uuid": "^3.0.1"
   }
 }


### PR DESCRIPTION
I expect this is a pattern that we will be applying elsewhere.  I wonder if we should add a permission check before the query to determine if the user has PERMISSIONS.LDN_INBOX_ACCESS for any resource at all .
If we do not, a user with no permissions at all will be able to cause the API to return/filter the entire collection just to return [].  We need to figure out what proper protections should be put in place in the HTTP for this reason as well.